### PR TITLE
Lists index

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  # Temporary way to set current_user until authentication is added
+  def current_user
+    @current_user ||= User.first || raise("No user found")
+  end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,0 +1,5 @@
+class ListsController < ApplicationController
+  def index
+    @lists = current_user.lists
+  end
+end

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,0 +1,6 @@
+<h1>Here are your lists</h1>
+
+<% @lists.each do |list| %>
+  <div><%= list.title %></div>
+  <div><%= list.description %></div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,7 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "lists#index"
+
+  resources :lists, only: [ :index ]
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,8 @@ RSpec.configure do |config|
 
   # Include Factory Bot syntax to simplify calls to factories
   config.include FactoryBot::Syntax::Methods
+
+  config.include Capybara::RSpecMatchers, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/lists_spec.rb
+++ b/spec/requests/lists_spec.rb
@@ -14,17 +14,14 @@ RSpec.describe "Lists", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "renders content from the index template" do
-      expect(response.body).to include("Here are your lists")
+    it "renders the header" do
+      expect(response.body).to have_text("Here are your lists")
     end
 
-    it "returns all lists for the user" do
+    it "sets lists and renders the user's lists" do
       expect(lists.count).to eq(list_count)
-
-      lists.each do |list|
-        expect(response.body).to have_text(list.title)
-        expect(response.body).to have_text(list.description)
-      end
+      expect(response.body).to have_text(lists.first.title)
+      expect(response.body).to have_text(lists.first.description)
     end
   end
 end

--- a/spec/requests/lists_spec.rb
+++ b/spec/requests/lists_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe "Lists", type: :request do
+  describe "GET /index" do
+    let!(:user) { create(:user) }
+    let(:list_count) { 3 }
+    let!(:lists) { create_list(:list, list_count, user: user) }
+
+    before do
+      get lists_path
+    end
+
+    it "returns a successful response" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders content from the index template" do
+      expect(response.body).to include("Here are your lists")
+    end
+
+    it "returns all lists for the user" do
+      expect(lists.count).to eq(list_count)
+
+      lists.each do |list|
+        expect(response.body).to have_css("div", text: "#{list.title}")
+        expect(response.body).to have_css("div", text: "#{list.description}")
+      end
+    end
+  end
+end

--- a/spec/requests/lists_spec.rb
+++ b/spec/requests/lists_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "Lists", type: :request do
       expect(lists.count).to eq(list_count)
 
       lists.each do |list|
-        expect(response.body).to have_css("div", text: "#{list.title}")
-        expect(response.body).to have_css("div", text: "#{list.description}")
+        expect(response.body).to have_text(list.title)
+        expect(response.body).to have_text(list.description)
       end
     end
   end


### PR DESCRIPTION
Adds basic setup to:
- Temporarily default current_user based on seeds (until authentication implemented)
- Sets root to lists#index
- Render basic lists index page
- Basic requests specs for lists controller